### PR TITLE
Update mol.py

### DIFF
--- a/mmic_parmed/models/mol.py
+++ b/mmic_parmed/models/mol.py
@@ -95,7 +95,7 @@ class ParmedMol(ToolkitModel):
             "schema_name": data.schema_name,
         }
         out = MolToParmedComponent.compute(inputs)
-        return cls(data=out.data_object, units=out.data_units)
+        return cls(data=out.data_object, data_units=out.data_units)
 
     def to_file(self, filename: str, dtype: str = None, mode: str = "w", **kwargs):
         """Writes the molecule to a file.


### PR DESCRIPTION
Replace line 98 by 'return cls(data=out.data_object, data_units=out.data_units)'

## Description
Solves a minor bug in mol.py

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Check if it can be used by other repos smoothly 

## Questions
- [ ] 'out' instance still does not have an attribute named data_units. Does this matter?

## Status
- [ ] Ready to go