### PR TITLE
Fix hash code inconsistency

### DIFF
--- a/mmic_parmed/components/mol_component.py
+++ b/mmic_parmed/components/mol_component.py
@@ -243,7 +243,10 @@ class ParmedToMolComponent(TacticComponent):
 
         # I think parmed.Structure does not store forces
         pmol = inputs.data_object
-        geo_units, vel_units = None, None
+        geo_units = Molecule.default_units[
+            "geometry_units"
+        ]  # update later if specified
+        vel_units = Molecule.default_units["velocities_units"]
 
         geo = getattr(pmol, "coordinates", None)
         if geo is not None:  # General enough? hackish?


### PR DESCRIPTION
## Description
Fixes bug with inconsistent hash code generated by MMElemental because of missing `velocities_units` in [ParmedToMolComponent ](https://github.com/MolSSI/mmic_parmed/blob/f6263d852e4c434478ed2351d87f9a9dcd025c4f/mmic_parmed/components/mol_component.py#L246) reported in [here](https://github.com/MolSSI/mmic_parmed/issues/6).

## Status
- [x] Ready to go